### PR TITLE
Refactor/decouple latency metric from rest client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ url = "2.3.1"
 hmac = "0.12.1"
 sha2 = "0.10.6"
 hex = "0.4.3"
+base64 = "0.22.0"
 
 # Misc
 chrono = { version = "0.4.21", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -179,10 +179,6 @@ impl RestRequest for FetchBalancesRequest {
     fn method() -> reqwest::Method {
         reqwest::Method::GET
     }
-
-    fn metric_tag() -> Tag {
-        Tag::new("method", "fetch_balances")
-    }
 }
 
 #[derive(Deserialize)]
@@ -204,9 +200,6 @@ struct FtxBalance {
 /// box to execute trades on many exchanges.
 #[tokio::main]
 async fn main() {
-    // Construct Metric channel to send Http execution metrics over
-    let (http_metric_tx, _http_metric_rx) = mpsc::unbounded_channel();
-
     // HMAC-SHA256 encoded account API secret used for signing private http requests
     let mac: Hmac<sha2::Sha256> = Hmac::new_from_slice("api_secret".as_bytes()).unwrap();
 
@@ -220,7 +213,7 @@ async fn main() {
     );
 
     // Build RestClient with Ftx configuration
-    let rest_client = RestClient::new("https://ftx.com", http_metric_tx, request_signer, FtxParser);
+    let rest_client = RestClient::new("https://ftx.com", request_signer, FtxParser);
 
     // Fetch Result<FetchBalancesResponse, ExecutionError>
     let _response = rest_client.execute(FetchBalancesRequest).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ where
             stream,
             transformer,
             buffer: VecDeque::with_capacity(6),
-            protocol_marker: PhantomData::default(),
+            protocol_marker: PhantomData,
         }
     }
 }

--- a/src/protocol/http/mod.rs
+++ b/src/protocol/http/mod.rs
@@ -4,16 +4,16 @@ use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use tracing::error;
 
-/// Defines an abstract [`RestRequest`](rest::RestRequest) that can be executed by a fully
+/// Defines an abstract [`RestRequest`] that can be executed by a fully
 /// configurable [`RestClient`](rest::client::RestClient).
 pub mod rest;
 
 /// Defines a configurable [`RequestSigner`](private::RequestSigner) that signs Http
-/// [`RestRequest`](rest::RestRequest) using API specific logic.
+/// [`RestRequest`] using API specific logic.
 pub mod private;
 
 /// Defines a default [`BuildStrategy`] that builds a non-authenticated Http
-/// [`RestRequest`](rest::RestRequest) with no headers.
+/// [`RestRequest`] with no headers.
 pub mod public;
 
 /// [`RestRequest`] build strategy for the API being interacted with.
@@ -39,7 +39,7 @@ pub trait BuildStrategy {
 }
 
 /// Utilised by a [`RestClient`](rest::client::RestClient) to deserialise
-/// [`RestRequest::Response`](rest::RestRequest::Response), and upon failure parses API errors
+/// [`RestRequest::Response`], and upon failure parses API errors
 /// returned from the server.
 pub trait HttpParser {
     type ApiError: DeserializeOwned;

--- a/src/protocol/http/private/encoder.rs
+++ b/src/protocol/http/private/encoder.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+
 /// Encodes bytes data.
 pub trait Encoder {
     /// Encodes the bytes data into some `String` format.
@@ -16,5 +18,18 @@ impl Encoder for HexEncoder {
         Bytes: AsRef<[u8]>,
     {
         hex::encode(data)
+    }
+}
+
+/// Encodes bytes data as a base64 `String`.
+#[derive(Debug, Copy, Clone)]
+pub struct Base64Encoder;
+
+impl Encoder for Base64Encoder {
+    fn encode<Bytes>(&self, data: Bytes) -> String
+    where
+        Bytes: AsRef<[u8]>,
+    {
+        base64::engine::general_purpose::STANDARD.encode(data)
     }
 }

--- a/src/protocol/http/rest/mod.rs
+++ b/src/protocol/http/rest/mod.rs
@@ -1,4 +1,3 @@
-use crate::metric::Tag;
 use serde::{de::DeserializeOwned, Serialize};
 use std::time::Duration;
 
@@ -25,9 +24,6 @@ pub trait RestRequest {
 
     /// Http [`reqwest::Method`] of this request.
     fn method() -> reqwest::Method;
-
-    /// [`Metric`](crate::metric::Metric) [`Tag`](crate::metric::Tag) that identifies this request.
-    fn metric_tag() -> Tag;
 
     /// Optional query parameters for this request.
     fn query_params(&self) -> Option<&Self::QueryParams> {


### PR DESCRIPTION
Refactor:
- De-couple RestClient latency Metric from communication mechanism. 

Feature:
- Add `Base64Encoder` `trait Encoder` implementation.  